### PR TITLE
Update ssvmrpc_service_specification.md

### DIFF
--- a/documentation/specifications/ssvmrpc_service_specification.md
+++ b/documentation/specifications/ssvmrpc_service_specification.md
@@ -63,7 +63,7 @@ The following data object provides the command line call with the appropriate ar
                         "2"
                 ],
                 "argument_types": ["i32", "i32"], 
-	        "return_type": "i32",
+                "return_types": ["i32"],
                 "vm_snapshot": {
                     "global" : [
                         [0, "0x00000000FFFFFFFF"], [1, "0x00000000FFFFFFFF"]


### PR DESCRIPTION
Change key "return_type" to "return_types".
Use a list of return value in "return_types" instead of using a string for multi-value extension in the future.